### PR TITLE
Added "multiline" flag to errorMatch regex

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -127,7 +127,7 @@ module.exports = {
     if (!this.cmd.errorMatch) {
       return;
     }
-    var regex = XRegExp(this.cmd.errorMatch);
+    var regex = XRegExp(this.cmd.errorMatch, 'm');
     var match =
       XRegExp.exec(this.stderr.toString('utf8'), regex) ||
       XRegExp.exec(this.stdout.toString('utf8'), regex);


### PR DESCRIPTION
When a build fails, depending on the compiler's output, the error message could span multiple lines. If the location of the error within the source code is not specified on the first line, the build:error-match function cannot jump to the right location. By enabling multiline regexes, one could match against the whole output.

I stumbled upon this issue while trying to add a build configuration to a [Nim](https://github.com/Araq/Nim) project.
